### PR TITLE
Dandelion dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /generated
 /target
 .vscode
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /generated
 /target
 .vscode
-tmp

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ pub struct CmdLineOpts {
     /// Path to output directory
     #[clap(default_value = "./generated")]
     output_directory: std::path::PathBuf,
-    /// Customize the name of the generated Rust crate
+    /// Customize the name of the generated Rust crate.
+    /// Default: sandboxed-<input-file-name-base>
     #[clap(long)]
     crate_name: Option<String>,
     /// Prevent reformatting, for debug purposes

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,12 +90,6 @@ pub struct CmdLineOpts {
     /// (Warning: experimental performance impact)
     #[clap(long)]
     no_alloc: bool,
-    /// Generate a module which can be passed a custom memory buffer for the
-    /// WebAssembly memory.
-    /// This option is automatically activated if the module imports its memory.
-    /// (Warning: experimental performance impact)
-    #[clap(long)]
-    extern_memory: bool,
 }
 
 fn main() -> Maybe<()> {
@@ -127,17 +121,11 @@ fn main() -> Maybe<()> {
         }
         opts.no_std_library = true;
     }
-    // if opts.extern_memory {
-    //     if opts.fixed_mem_size.is_none() {
-    //         return Err(eyre!("Must use --fixed-mem-size when using --extern-memory"));
-    //     }
-    // }
 
     let inp = std::fs::read(&opts.input_path)?;
     println!("Finished reading");
     let module = parser::parse(&inp)?;
     println!("Finished parsing");
-    opts.extern_memory = opts.extern_memory || module.imports_memory();
     printer::print_module(&module, &opts)?;
 
     println!("Finished");

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,11 @@ pub struct CmdLineOpts {
     /// Generate a `no_std` library, limiting usage to `core` and `alloc`
     #[clap(long)]
     no_std_library: bool,
+    /// Generate statically allocated, heapless code (implies --no-std-library,
+    /// requires --fixed-mem-size)
+    /// (Warning: experimental performance impact)
+    #[clap(long)]
+    no_alloc: bool,
 }
 
 fn main() -> Maybe<()> {
@@ -105,6 +110,12 @@ fn main() -> Maybe<()> {
     }
     if opts.generate_as_wasi_library {
         opts.generate_wasi_executable = true;
+    }
+    if opts.no_alloc {
+        if opts.fixed_mem_size.is_none() {
+            return Err(eyre!("Must use --fixed-mem-size when using --no-alloc"));
+        }
+        opts.no_std_library = true;
     }
 
     let inp = std::fs::read(&opts.input_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ pub struct CmdLineOpts {
     /// Path to output directory
     #[clap(default_value = "./generated")]
     output_directory: std::path::PathBuf,
+    /// Customize the name of the generated Rust crate
+    #[clap(long)]
+    crate_name: Option<String>,
     /// Prevent reformatting, for debug purposes
     #[clap(short, long)]
     prevent_reformat: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,11 @@ pub struct CmdLineOpts {
     /// (Warning: experimental performance impact)
     #[clap(long)]
     no_alloc: bool,
+    /// Generate a module which can be passed a custom memory buffer for the
+    /// WebAssembly memory. This currently only works with --fixed-mem-size.
+    /// (Warning: experimental performance impact)
+    #[clap(long)]
+    extern_memory: bool,
 }
 
 fn main() -> Maybe<()> {
@@ -120,6 +125,11 @@ fn main() -> Maybe<()> {
             return Err(eyre!("Must use --fixed-mem-size when using --no-alloc"));
         }
         opts.no_std_library = true;
+    }
+    if opts.extern_memory {
+        if opts.fixed_mem_size.is_none() {
+            return Err(eyre!("Must use --fixed-mem-size when using --extern-memory"));
+        }
     }
 
     let inp = std::fs::read(&opts.input_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,8 @@ pub struct CmdLineOpts {
     #[clap(long)]
     no_alloc: bool,
     /// Generate a module which can be passed a custom memory buffer for the
-    /// WebAssembly memory. This currently only works with --fixed-mem-size.
+    /// WebAssembly memory.
+    /// This option is automatically activated if the module imports its memory.
     /// (Warning: experimental performance impact)
     #[clap(long)]
     extern_memory: bool,
@@ -126,16 +127,17 @@ fn main() -> Maybe<()> {
         }
         opts.no_std_library = true;
     }
-    if opts.extern_memory {
-        if opts.fixed_mem_size.is_none() {
-            return Err(eyre!("Must use --fixed-mem-size when using --extern-memory"));
-        }
-    }
+    // if opts.extern_memory {
+    //     if opts.fixed_mem_size.is_none() {
+    //         return Err(eyre!("Must use --fixed-mem-size when using --extern-memory"));
+    //     }
+    // }
 
     let inp = std::fs::read(&opts.input_path)?;
     println!("Finished reading");
     let module = parser::parse(&inp)?;
     println!("Finished parsing");
+    opts.extern_memory = opts.extern_memory || module.imports_memory();
     printer::print_module(&module, &opts)?;
 
     println!("Finished");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,6 @@
+// parser macros yield unused assignments in the last parser
+#![allow(dead_code, unused_assignments)]
+
 use crate::wasm::syntax::*;
 use crate::Maybe;
 use color_eyre::eyre::eyre;
@@ -189,6 +192,7 @@ fn peek(inp: &[u8], n: usize) -> Parsed<&[u8]> {
     Ok((inp, v))
 }
 
+#[allow(unused)]    // could be useful in the future
 fn peek_at(inp: &[u8], pos: usize) -> Parsed<&u8> {
     let v = inp.get(pos).ok_or(eyre!("Insufficient data for parsing"))?;
     Ok((inp, v))
@@ -203,6 +207,7 @@ fn inp(inp: &[u8], n: usize) -> Parsed<&[u8]> {
     Ok((&inp[n..], v))
 }
 
+#[allow(unused)]    // could be useful in the future
 fn inp_dump(inp: &[u8]) -> Parsed<()> {
     trace!("Remaining: {:#x?}", inp);
     Ok((inp, ()))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -873,7 +873,7 @@ generate! { module -> Module = {
     let names = {
         if let Some(data) = custom.get("name") {
             let mut data: &[u8] = data;
-            let names = run_manual!(names(data));
+            let names = run_parser!(names(data));
             // below check seems broken, see https://github.com/secure-foundations/rWasm/issues/2
             // if data.len() == 0 {
             //     names

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -823,11 +823,12 @@ generate! { module -> Module = {
         if let Some(data) = custom.get("name") {
             let mut data: &[u8] = data;
             let names = run_manual!(names(data));
-            if data.len() == 0 {
-                names
-            } else {
-                err!("Unused bytes in the custom name section")
-            }
+            // below check seems broken, see https://github.com/secure-foundations/rWasm/issues/2
+            // if data.len() == 0 {
+            //     names
+            // } else {
+            //     err!("Unused bytes in the custom name section")
+            // }
         } else {
             Names {
                 module: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -874,14 +874,11 @@ generate! { module -> Module = {
         if let Some(data) = custom.get("name") {
             let mut data: &[u8] = data;
             let names = run_parser!(names(data));
-            names
-
-            // below check seems broken, see https://github.com/secure-foundations/rWasm/issues/2
-            // if data.len() == 0 {
-            //     names
-            // } else {
-            //     err!("Unused bytes in the custom name section")
-            // }
+            if data.len() == 0 {
+                names
+            } else {
+                err!("Unused bytes in the custom name section")
+            }
         } else {
             Names {
                 module: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -829,6 +829,7 @@ generate! { module -> Module = {
             // } else {
             //     err!("Unused bytes in the custom name section")
             // }
+            names
         } else {
             Names {
                 module: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -121,7 +121,7 @@ macro_rules! with_dollar_sign {
 /// ```
 /// expands to
 /// ```ignore
-/// fn double_peek(mut inp: &[u8], n:u32) -> Parsed<type> {
+/// fn double_peek(mut inp: &[u8], n:u32) -> Parsed<&[u32]> {
 ///     let v = {
 ///         let (inp1, v) = peek(inp, 2*n)?;
 ///         inp = inp1;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1484,16 +1484,12 @@ fn print_data(self_name: &str, d: &wasm::syntax::Data) -> Maybe<String> {
             .map(|b| format!("{}", b))
             .collect::<Vec<_>>()
             .join(", ");
-        // we're not using `.copy_from_slice` because it is not const
-        // this allows for static initialization
         Ok(format!(
-            "// initialize data region [{offset}..{offset}+{len}]
-            let bytes = [{bytes}];
-            let mut i = {offset};
-            while i < {offset} + {len} {{
-                {self_name}.memory[i] = bytes[i - {offset}];
-                i += 1;
-            }}"
+            "{}.memory[{}..{}].copy_from_slice(&[{}]);",
+            self_name,
+            offset,
+            offset + len,
+            bytes
         ))
     } else {
         Err(eyre!("Currently unsupported expression for data offset"))?

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1849,6 +1849,9 @@ fn print_export(
                     pub fn get_memory(&mut self) -> *mut u8 {
                         self.memory.as_mut_ptr()
                     }
+                    pub fn get_memory_size(&self) -> usize {
+                        self.memory.len()
+                    }
                 }"
                 .to_string())
             }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1927,14 +1927,11 @@ edition = "2018"
 
 [profile.release]
 debug = true
-{panic}
             "#,
             name = package_name,
             version = crate::PROGRAM_VERSION,
             generator = crate::PROGRAM_NAME,
             dependencies = dependencies,
-            panic = if opts.no_alloc { "panic = \"abort\"" } 
-            else { "" },
         ),
     )?)
 }
@@ -1994,15 +1991,6 @@ fn print_generated_code_prefix(m: &wasm::syntax::Module, opts: &CmdLineOpts) -> 
         "#![no_std]\n"
     } else {
         ""
-    };
-    let panic_handler = if !opts.no_alloc {
-        "".into()
-    } else {
-        format!("
-            #[panic_handler]
-            fn panic(_info: &PanicInfo) -> ! {{
-                loop {{}}
-            }}")
     };
     // If we need to avoid alloc dependency, we need to generate
     // arrays for the return values of functions (can't use `Vec`).
@@ -2133,14 +2121,12 @@ fn print_generated_code_prefix(m: &wasm::syntax::Module, opts: &CmdLineOpts) -> 
     Ok(format!(
         "{module_prefix}{no_std}\n\n\
          {imports}\n\n\
-         {panic_handler}\n\n
          {tagged_value_definitions}\n\n\
          {static_function_return_def}
          {wasm_module}\n\n\
          {memory_accessors}\n",
         module_prefix = module_prefix,
         no_std = no_std,
-        panic_handler = panic_handler,
         imports = if opts.no_alloc {
             include_str!("../templates-for-generation/imports_no_alloc.rs")
         } else if opts.no_std_library {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1888,6 +1888,14 @@ fn print_export(
 
 fn print_cargo_toml(opts: &CmdLineOpts) -> Maybe<()> {
     let cargo_toml_path = opts.output_directory.join("Cargo.toml");
+    if cargo_toml_path.exists() {
+        println!(
+            "WARNING: Cargo.toml already exists at {}. \
+             Not overwriting it.",
+            cargo_toml_path.display()
+        );
+        return Ok(());
+    }
     let package_name = opts
         .input_path
         .file_stem()

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1896,11 +1896,14 @@ fn print_cargo_toml(opts: &CmdLineOpts) -> Maybe<()> {
         );
         return Ok(());
     }
-    let package_name = opts
-        .input_path
-        .file_stem()
-        .and_then(|n| n.to_str())
-        .unwrap_or("wasmmodule".into());
+    let package_name = match &opts.crate_name {
+        Some(n) => n.clone(),
+        None => "sandboxed-".to_owned() + opts
+            .input_path
+            .file_stem()
+            .and_then(|n| n.to_str())
+            .unwrap_or("wasmmodule".into())
+        };
     let dependencies = if opts.generate_wasi_executable {
         "\
         wasi-common = \"0.20.0\"\n\
@@ -1914,7 +1917,7 @@ fn print_cargo_toml(opts: &CmdLineOpts) -> Maybe<()> {
         format!(
             r#"
 [package]
-name = "sandboxed-{name}"
+name = "{name}"
 version = "{version}"
 authors = ["generated-by-{generator}-{version}"]
 edition = "2018"

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -2089,7 +2089,7 @@ fn print_generated_code_prefix(m: &wasm::syntax::Module, opts: &CmdLineOpts) -> 
                 "<'a>"
             }
         },
-        memory = format!("memory: {}", mem_type(m, opts)),
+        memory = format!("pub memory: {}", mem_type(m, opts)),
         globals = if opts.no_alloc {
             format!(
                 "globals: [TaggedVal; {}]",

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -2199,7 +2199,7 @@ pub fn print_module(m: &wasm::syntax::Module, opts: &CmdLineOpts) -> Maybe<()> {
     generated += &format!(
         "impl WasmModule {{
              #[allow(unused_mut)]
-             pub const fn new() -> Self {{
+             pub fn new() -> Self {{
                  let mut m = WasmModule {{
                      {memory_init},
                      {globals_init},

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -328,6 +328,15 @@ pub mod syntax {
             pub names: Names, // non-standard custom section that appears in WASI
         }
 
+        impl Module {
+            pub fn imports_memory(&self) -> bool {
+                self.imports.iter().any(|i| match &i.desc {
+                    ImportDesc::Mem(_) => true,
+                    _ => false,
+                })
+            }
+        }
+
         pub struct Names {
             pub module: Option<Name>,
             pub functions: std::collections::HashMap<FuncIdx, Name>,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -328,15 +328,6 @@ pub mod syntax {
             pub names: Names, // non-standard custom section that appears in WASI
         }
 
-        impl Module {
-            pub fn imports_memory(&self) -> bool {
-                self.imports.iter().any(|i| match &i.desc {
-                    ImportDesc::Mem(_) => true,
-                    _ => false,
-                })
-            }
-        }
-
         pub struct Names {
             pub module: Option<Name>,
             pub functions: std::collections::HashMap<FuncIdx, Name>,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -186,6 +186,22 @@ pub mod syntax {
             }
         }
 
+        impl Const {
+            /// Convert to a string and include the variant name.
+            /// Example: `Const::I32(42).to_variant_str()` returns `"I32(42i32)"`
+            /// whereas `Const::I32(42).to_string()` returns `"42i32"`.
+            pub fn to_variant_string(&self) -> String {
+                use Const::*;
+                let variant_str: String = match self {
+                    I32(_) => "I32".into(),
+                    I64(_) => "I64".into(),
+                    F32(_) => "F32".into(),
+                    F64(_) => "F64".into(),
+                };
+                format!("{}({})", variant_str, self.to_string())
+            }
+        }
+
         #[derive(Debug)]
         pub enum BitSize {
             B32,

--- a/templates-for-generation/imports_no_alloc.rs
+++ b/templates-for-generation/imports_no_alloc.rs
@@ -1,4 +1,3 @@
 use core::convert::TryInto;
 use core::ops::Index;
 use core::ops::IndexMut;
-use core::panic::PanicInfo;

--- a/templates-for-generation/imports_no_alloc.rs
+++ b/templates-for-generation/imports_no_alloc.rs
@@ -1,0 +1,4 @@
+use core::convert::TryInto;
+use core::ops::Index;
+use core::ops::IndexMut;
+use core::panic::PanicInfo;

--- a/templates-for-generation/static_func_returns.rs
+++ b/templates-for-generation/static_func_returns.rs
@@ -8,6 +8,7 @@ enum IndirectFuncRet {
 }
 
 impl IndirectFuncRet {
+    #[allow(dead_code)]
     fn len(&self) -> usize {
         use IndirectFuncRet::*;
         match self {

--- a/templates-for-generation/static_func_returns.rs
+++ b/templates-for-generation/static_func_returns.rs
@@ -1,0 +1,36 @@
+/// A common heapless return type for indirect calls.
+/// Notice wasm functions have multi-returns. In order to
+/// avoid heap allocation, call_indirect() returns this type
+/// instead of Vec<TaggedVal>.
+#[derive(Copy, Clone, Debug)]
+enum IndirectFuncRet {
+    <<RETDEFS>>
+}
+
+impl IndirectFuncRet {
+    fn len(&self) -> usize {
+        use IndirectFuncRet::*;
+        match self {
+            <<RETCOUNTS>>
+        }
+    }
+}
+
+impl Index<usize> for IndirectFuncRet {
+    type Output = TaggedVal;
+    fn index<'a>(&'a self, i: usize) -> &'a TaggedVal {
+        use IndirectFuncRet::*;
+        match self {
+            <<RETINDEXES>>
+        }
+    }
+}
+
+impl IndexMut<usize> for IndirectFuncRet {
+    fn index_mut<'a>(&'a mut self, i: usize) -> &'a mut TaggedVal {
+        use IndirectFuncRet::*;
+        match self {
+            <<RETINDEXESMUT>>
+        }
+    }
+}

--- a/templates-for-generation/tagged_value_definitions.rs
+++ b/templates-for-generation/tagged_value_definitions.rs
@@ -39,7 +39,7 @@ macro_rules! tagged_value_conversion {
         impl TaggedVal {
             #[inline]
             #[allow(dead_code)]
-            fn $try_as(&self) -> Option<$ty> {
+            const fn $try_as(&self) -> Option<$ty> {
                 if let $e(v) = self {
                     Some(*v)
                 } else {


### PR DESCRIPTION
This PR adds

- minor refactoring of parser
- some documentation
- option `--no-alloc`
- option `--crate-name`
- memory import support

notes on the changes to the code:

- indirect function returns
    - rWasm used to return a `Vec` from indirect function calls. If option`no-alloc` is given it now uses a new enum which will allocate an upper bound of space needed for the returns on the stack.
- memory changes
    - When memory is declared imported, a reference to the applicable memory type is required on module creation. The reference type required me to add lifetime annotations.
    - I eliminated the use of `Box` to keep it "simple" with `--no-alloc`.
        - A `Vec` already lives on the heap, and a `&mut [u8]` can too.
        - But a memory of type `mut [u8]` (`--fixed-mem-size` + _not_ imported memory) now necessarily lives on the stack.
    - currently, `--no-alloc` requires `--fixed-mem-size`
    - memory should probably be simplified
        - see the new `mem_type()` function
        - e.g. could define  a `trait MemoryType`
            - notice that for a `Vec<T>`-like type, `T` should probably be `Sized`, which can't be dynamically dispatched (so no `MemoryType` trait objects)
        - The [allocator-api](https://doc.rust-lang.org/beta/unstable-book/library-features/allocator-api.html) would allow for using a `Vec` with a custom memory allocator provided by the user, but I wouldn't expect anything to land in stable soon. 
- I made some functions `const` so they can be used for `static` definitions.
- added some comments and subjective styling changes to `parser.rs`
- possibly a bugfix in section parsing (see comment in code)
- [TODO reference]
    - I removed the code causing the problem, but didn't fix the underlying issue.

I think `parser.rs` really needs some syntactic simplifications but I couldn't come up with a nice solution yet. I did some sanity checks but didn't test thoroughly, I think rWasm should get some CI tests.